### PR TITLE
steamCMD bitness fix

### DIFF
--- a/ogp_agent.pl
+++ b/ogp_agent.pl
@@ -2165,7 +2165,7 @@ sub steam_cmd_without_decrypt
 	
 	# Handle requested SteamCMD architecture
 	if(defined $arch_bits && $arch_bits ne ""){
-		print FILE "\@sSteamCmdForcePlatformBitness =\"" . $arch_bits . "\"\n";
+		print FILE "\@sSteamCmdForcePlatformBitness " . $arch_bits . "\n";
 	}
 	
 	if($guard ne '')


### PR DESCRIPTION
tested and  correctly installs 32 bit binaries for unturned with modified XML

I noticed though that between Agent and Panel files, the bitness variable has three different names, maybe it could be modified so it uses the same name everywhere instead of

$arch
$archBits
$arch_bits