### PR TITLE
Check that socket is still alive before writing

### DIFF
--- a/KKrcon/HL2.pm
+++ b/KKrcon/HL2.pm
@@ -89,9 +89,13 @@ sub run {
 	}
 
 	my $socket = $self->socket();
-	print $socket $self->packet(CMD, $command);
-
-	return $self->response();
+	if($socket->connected)
+	{
+		print $socket $self->packet(CMD, $command);
+		return $self->response();
+	}
+	
+	return;
 }
 
 # create tcp socket


### PR DESCRIPTION
Writing to a disconnected socket causes process to be terminated by SIGPIPE.
Here it also stop the routine "stop_server_without_decrypt" and causes to not stopping server.