### PR TITLE
Correct replace_OGP_Env_Vars call to include screen_id

### DIFF
--- a/ogp_agent.pl
+++ b/ogp_agent.pl
@@ -906,7 +906,7 @@ sub universal_start_without_decrypt
 		my @prestartenvvars = split /[\r\n]+/, $envVars;
 		my $envVarStr = "";
 		foreach my $line (@prestartenvvars) {
-			$line = replace_OGP_Env_Vars("", $home_id, $home_path, $line, $game_key);
+			$line = replace_OGP_Env_Vars($screen_id, $home_id, $home_path, $line, $game_key);
 			if($line ne ""){
 				logger "Configuring environment variable: $line";
 				$envVarStr .= "$line\n";


### PR DESCRIPTION
$screen_id was missing from the call to replace_OGP_Env_Vars when parsing environment variables, meaning the steamcmd specific special entries would never work in a game XML's environment variables.

I made this request in order to improve upon the CS2 xml and make it up to OGP standards.
Pull Request for Website: https://github.com/OpenGamePanel/OGP-Website/pull/657
Pull Request for Agent (Windows): https://github.com/OpenGamePanel/OGP-Agent-Windows/pull/29